### PR TITLE
Added automatic dependency installs (FastTree, pplacer, mothur)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -276,6 +276,7 @@ def install_fasttree(mac_os,install_scripts, replace_install=None):
                 print("WARNING: Errors installing FastTree.")
         else: 
             download(fastTree_url,download_file)
+            os.chmod(download_file, 0o755)
         print("Installing FastTree.")
     else:
         print("Found FastTree install.")
@@ -323,7 +324,7 @@ def install_pplacer(mac_os,install_scripts, replace_install=None):
     pplacer_installed=find_exe_in_path("pplacer")      
     pplacer_exe = "pplacer"
     pplacer_file="pplacer-linux-v1.1.alpha19.zip"
-    pplacer_filename="pplacer-linux-v1.1.alpha19"
+    pplacer_filename="pplacer-Linux-v1.1.alpha19"
     pplacer_url ="https://github.com/matsen/pplacer/releases/download/v1.1.alpha19/pplacer-linux-v1.1.alpha19.zip"
     
 	# install pplacer if not already installed

--- a/setup.py
+++ b/setup.py
@@ -196,6 +196,178 @@ def download_unpack_zip(url, download_file_name, folder, software_name):
 		except EnvironmentError:
 			print("WARNING: Unable to remove the temp download: " + download_file)
 
+def download_wget_unpack_zip(url, download_file_name, folder, software_name):
+	"""
+	Download the url to the file and decompress into the folder
+	"""
+
+	# Check for write permission to the target folder
+	if not os.access(folder, os.W_OK):
+		print("WARNING: The directory is not writeable: " +
+		      folder + " . Please modify the permissions.")
+
+	download_file = os.path.join(folder, download_file_name)
+
+	try:
+		subprocess.call(["wget",url,"--directory-prefix="+folder])
+	except (EnvironmentError,subprocess.CalledProcessError):				
+		print("WARNING: Errors downloading mothur.")
+
+	error_during_extract = False
+
+	try:
+		zipfile_handle = zipfile.ZipFile(download_file)
+		zipfile_handle.extractall(path=folder)
+		zipfile_handle.close()
+	except EnvironmentError:
+		print("WARNING: Unable to extract " + software_name + ".")
+		error_during_extract = True
+
+	if not error_during_extract:
+		try:
+			os.unlink(download_file)
+		except EnvironmentError:
+			print("WARNING: Unable to remove the temp download: " + download_file)
+
+
+def find_exe_in_path(exe):
+    """
+    Check that an executable exists in $PATH
+    """
+    
+    paths = os.environ["PATH"].split(os.pathsep)
+    for path in paths:
+        fullexe = os.path.join(path,exe)
+        if os.path.exists(fullexe):
+            if os.access(fullexe,os.X_OK):
+                return path
+    return None
+
+def install_fasttree(mac_os,install_scripts, replace_install=None):
+    """ 
+    Download and install the FastTree software if not already installed
+    """
+    
+    # Download the FastTree software
+    # Check to see if already downloaded
+    fasttree_installed=find_exe_in_path("FastTree")
+    fastTree_file="FastTree"            
+    fastTree_url ="http://www.microbesonline.org/fasttree/FastTree"
+    download_file=os.path.join(install_scripts, fastTree_file)
+    
+	# install fastTree if not already installed
+    if not fasttree_installed or replace_install:
+        if mac_os:
+            fastTree_file="FastTree.c"
+            fastTree_url="http://www.microbesonline.org/fasttree/FastTree.c"
+            download_file=os.path.join(install_scripts, fastTree_file)
+            download(fastTree_url,download_file)
+			
+			#Check for GCC Version
+            try:
+                subprocess_output=subprocess.check_output(["gcc","--version"])
+            except (EnvironmentError,subprocess.CalledProcessError):
+                print("WARNING: Please install gcc.")
+
+			#Install FastTree for MacOS	
+            try:
+                subprocess.call(["gcc","-O3","-finline-functions","-funroll-loops","-Wall","-o",install_scripts+"/FastTree",download_file,"-lm"])
+            except (EnvironmentError,subprocess.CalledProcessError):				
+                print("WARNING: Errors installing FastTree.")
+        else: 
+            download(fastTree_url,download_file)
+        print("Installing FastTree.")
+    else:
+        print("Found FastTree install.")
+
+def install_mothur(mac_os,install_scripts, replace_install=None):
+    """ 
+    Download and install the Mothur software if not already installed
+    """
+    # Download the Mothur software
+    mothur_installed=find_exe_in_path("mothur")      
+    mothur_exe = "mothur"
+    mothur_file="Mothur.linux_8.zip"
+    mothur_url ="https://github.com/mothur/mothur/releases/download/v1.48.1/Mothur.linux_8.zip"
+    
+	# install fastTree if not already installed
+    if not mothur_installed or replace_install:
+        if mac_os:
+            mothur_url="https://github.com/mothur/mothur/releases/download/v1.48.1/Mothur.OSX-10.14.zip"
+            mothur_file="Mothur.OSX-10.14.zip"
+
+        parathaa_source_folder=os.path.dirname(os.path.abspath(__file__))
+        tempfolder=tempfile.mkdtemp(prefix="mothur_download_",dir=parathaa_source_folder)	
+        download_wget_unpack_zip(mothur_url,mothur_file, tempfolder,mothur_exe)
+        mothur_exe_full_path=os.path.join(tempfolder,mothur_exe, mothur_exe) 
+               
+        # copy the installed software to the final bin location
+        try:
+            shutil.copy(mothur_exe_full_path, install_scripts)
+            os.chmod(os.path.join(install_scripts,mothur_exe), 0o755)
+        except (EnvironmentError, shutil.Error):
+            print("Error during Installing mothur. /bin Permission denied")
+        try:
+            shutil.rmtree(tempfolder)
+            print("Installed mothur.")
+        except EnvironmentError:
+            print("WARNING: Unable to remove temp install folder.")
+    else:
+        print("Found mothur install.")
+
+def install_pplacer(mac_os,install_scripts, replace_install=None):
+    """ 
+    Download and install the Mothur software if not already installed
+    """
+    # Download the pplacer software
+    pplacer_installed=find_exe_in_path("pplacer")      
+    pplacer_exe = "pplacer"
+    pplacer_file="pplacer-linux-v1.1.alpha19.zip"
+    pplacer_filename="pplacer-linux-v1.1.alpha19"
+    pplacer_url ="https://github.com/matsen/pplacer/releases/download/v1.1.alpha19/pplacer-linux-v1.1.alpha19.zip"
+    
+	# install pplacer if not already installed
+    if not pplacer_installed or replace_install:
+        if mac_os:
+            pplacer_url="https://github.com/smirarab/sepp/archive/refs/tags/4.5.1.zip"
+            pplacer_file="4.5.1.zip"
+            pplacer_filename="sepp-4.5.1/tools/bundled/Darwin"
+
+        parathaa_source_folder=os.path.dirname(os.path.abspath(__file__))
+        tempfolder=tempfile.mkdtemp(prefix="pplacer_download_",dir=parathaa_source_folder)	
+        download_wget_unpack_zip(pplacer_url,pplacer_file, tempfolder,pplacer_exe)
+        pplacer_exe_full_path=os.path.join(tempfolder,pplacer_filename, pplacer_exe) 
+        print("test"+pplacer_exe_full_path)
+               
+        # copy the installed software to the final bin location
+        try:
+            shutil.copy(pplacer_exe_full_path, install_scripts)
+            os.chmod(os.path.join(install_scripts,pplacer_exe), 0o755)
+        except (EnvironmentError, shutil.Error):
+            print("Error during Installing pplacer. /bin Permission denied")
+        try:
+            shutil.rmtree(tempfolder)
+            print("Installed pplacer.")
+        except EnvironmentError:
+            print("WARNING: Unable to remove temp install folder.")
+    else:
+        print("Found pplacer install.")
+
+class Install(_install):
+    """
+    Custom setuptools install command, set executable permissions for glpk
+    """
+    def run(self):
+        _install.run(self)
+        install_scripts=os.path.join(self.install_base, "bin")
+	    # find out the platform
+        mac_os=False
+        if sys.platform in ["darwin","os2","os2emx"]:
+            mac_os=True
+        install_fasttree(mac_os,install_scripts)
+        install_mothur(mac_os,install_scripts)
+        install_pplacer(mac_os,install_scripts)
+
 
 setuptools.setup(
 	name="parathaa",
@@ -218,7 +390,7 @@ setuptools.setup(
 	],
 	install_requires=['anadama2>=0.7.4','taxtastic'],
 	packages=setuptools.find_packages(),
-	# cmdclass={'install': Install},
+	cmdclass={'install': Install},
 	entry_points={
 		'console_scripts': [
 			'parathaa_run_tree_analysis = parathaa.run_tree_analysis:main',


### PR DESCRIPTION
Hi @nearinj , 
Here I have the Pull Request ready for the automatic installation of packages **1. fasttree, 2. mothur 3. pplacer** for both `Linux` and `MacOS`. Please feel free to test it on both environments and let me know if any issues. 

Notes: 
1. For `pplacer`, we are using their latest binary for Linux distro. However, for MacOS, `pplacer` binary in extracted from `sepp` package (https://github.com/smirarab/sepp/tree/master) as discussed in the thread.  

2. Since the all of the following dependencies expect R dependencies are now automatically installed for parathaa during the setup. Do we want to reflect that in our documentation section as well with what needs to be installed manually moving forward?  
```
PyPi
- anadama2 , taxtastic

Conda
- FastTree, pplacer, mothur
```

Regards,
Sagun